### PR TITLE
Add table of contents to markdown reviewer

### DIFF
--- a/src/apps/MarkdownReviewer/components/TableOfContents.tsx
+++ b/src/apps/MarkdownReviewer/components/TableOfContents.tsx
@@ -1,0 +1,85 @@
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+interface Heading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+interface TableOfContentsProps {
+  htmlContent: string;
+  previewRef: React.RefObject<HTMLDivElement>;
+}
+
+export function TableOfContents({ htmlContent, previewRef }: TableOfContentsProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const headings = useMemo(() => {
+    if (!htmlContent) return [];
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlContent, 'text/html');
+    const headingElements = doc.querySelectorAll('h1, h2, h3, h4, h5, h6');
+
+    return Array.from(headingElements).map((heading, index) => ({
+      id: `heading-${index}`,
+      text: heading.textContent || '',
+      level: parseInt(heading.tagName[1]),
+    }));
+  }, [htmlContent]);
+
+  const handleHeadingClick = (index: number) => {
+    if (!previewRef.current) return;
+
+    const headingElements = previewRef.current.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    const targetHeading = headingElements[index];
+
+    if (targetHeading) {
+      targetHeading.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
+  if (headings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 flex flex-col h-full">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-gray-50">
+        <h3 className="text-sm font-semibold text-gray-700">Table of Contents</h3>
+        <button
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          className="p-1 hover:bg-gray-200 rounded transition-colors"
+          title={isCollapsed ? 'Expand' : 'Collapse'}
+        >
+          {isCollapsed ? (
+            <ChevronRight className="w-4 h-4 text-gray-600" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-gray-600" />
+          )}
+        </button>
+      </div>
+
+      {!isCollapsed && (
+        <div className="flex-1 overflow-y-auto p-4">
+          <nav className="space-y-1">
+            {headings.map((heading, index) => (
+              <button
+                key={heading.id}
+                onClick={() => handleHeadingClick(index)}
+                className="w-full text-left py-1.5 px-2 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 rounded transition-colors block"
+                style={{
+                  paddingLeft: `${(heading.level - 1) * 12 + 8}px`,
+                }}
+                title={heading.text}
+              >
+                <span className="block truncate">{heading.text}</span>
+              </button>
+            ))}
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/apps/MarkdownReviewer/index.tsx
+++ b/src/apps/MarkdownReviewer/index.tsx
@@ -7,6 +7,7 @@ import { useTextSelection } from './hooks/useTextSelection';
 import { useComments } from './hooks/useComments';
 import { generateMarkdownExport, copyMarkdownToClipboard, downloadMarkdown } from './utils/exportUtils';
 import { FileListDialog } from './components/FileListDialog';
+import { TableOfContents } from './components/TableOfContents';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -267,7 +268,13 @@ export default function MarkdownReviewer() {
         </div>
       </div>
 
-      <div className="flex-1 grid grid-cols-[1fr_400px] gap-6 p-6 overflow-hidden">
+      <div className={`flex-1 grid ${markdownContent ? 'grid-cols-[250px_1fr_400px]' : 'grid-cols-[1fr_400px]'} gap-6 p-6 overflow-hidden`}>
+        {markdownContent && (
+          <div className="overflow-hidden">
+            <TableOfContents htmlContent={htmlContent} previewRef={previewRef} />
+          </div>
+        )}
+
         <Card className="bg-white rounded-lg p-6 shadow-sm flex flex-col overflow-hidden">
           <CardHeader className="p-0 pb-4">
             <CardTitle className="text-lg text-gray-800 border-b-2 border-blue-600 pb-2">Preview</CardTitle>


### PR DESCRIPTION
- Created TableOfContents component with heading extraction from HTML
- Added expand/collapse functionality for the TOC
- Implemented indentation based on heading levels (h1-h6)
- Added smooth scrolling when clicking TOC items
- Updated layout to include TOC on the left (250px width)
- Made layout responsive to hide TOC when no markdown is loaded